### PR TITLE
Darken buttons in footer when hovered

### DIFF
--- a/_sass/includes/_footer.scss
+++ b/_sass/includes/_footer.scss
@@ -12,6 +12,9 @@
             li {
                 display: inline;
             }
+            a:hover {
+                color: darken($link-color, 15%);
+            }
         }
     }
 }


### PR DESCRIPTION
This tiny PR unifies behaviour of share buttons and footer buttons. Share buttons darkened their background colour, while footer buttons did not - now they both behave the same way.

Though honestly, I'm not sure if it's better to have them both behave this way or maybe have both **not** change their background colours when hovered?