### PR TITLE
Ignore Gemfile.lock in Ruby 2.7.4 CI job

### DIFF
--- a/.github/workflows/gem-github-page.yml
+++ b/.github/workflows/gem-github-page.yml
@@ -23,7 +23,9 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Install github-pages gem 2.7.4
         continue-on-error: true
-        run: bundle install
+        run: |
+          rm -f Gemfile.lock
+          bundle install
         working-directory: ./.github/workflows/ruby-2.7.4
         if: matrix.ruby == '2.7.4'
       - name: Install github-pages gem


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
It was added to make the CI pass, let's see if we can adjust it so we don't need to keep it in the project at all.
